### PR TITLE
Remove PWM configuration from ILI9163C display definition

### DIFF
--- a/boards/shields/zest_display_lcd/zest_display_lcd.overlay
+++ b/boards/shields/zest_display_lcd/zest_display_lcd.overlay
@@ -42,7 +42,6 @@
 				width = <128>; \
 				height = <160>; \
 				rotation = <0>; \
-				pwms = <&sixtron_connector_##port##_pwm PWM1 1000000 PWM_POLARITY_NORMAL>; \
 			}; \
 		}; \
 	};


### PR DESCRIPTION
This pull request makes a minor change to the `zest_display_lcd.overlay` file by removing the `pwms` property from the display configuration for Zephyr 4.4.0 compatibility.

- Removed the `pwms` property from the display node in `zest_display_lcd.overlay`, eliminating the dependency on the PWM controller for the display.